### PR TITLE
Reduce JDK version from 21 to 17 in build configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    id("io.github.sparrow007.skyhigh.16kb-doctor") version "1.0.1"
+    id("io.github.sparrow007.skyhigh.16kb-doctor")
 }
 
 

--- a/skyhigh-16kb-doctor/plugin/build.gradle.kts
+++ b/skyhigh-16kb-doctor/plugin/build.gradle.kts
@@ -68,7 +68,7 @@ mavenPublishing {
 }
 
 mavenPublishing {
-    coordinates("io.github.sparrow007", "skyhigh-16kb-doctor", "1.0.1")
+    coordinates("io.github.sparrow007", "skyhigh-16kb-doctor", "1.0.2")
 
     pom {
         name.set("SkyHigh 16KB Doctor")

--- a/skyhigh-16kb-doctor/plugin/build.gradle.kts
+++ b/skyhigh-16kb-doctor/plugin/build.gradle.kts
@@ -15,12 +15,12 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(17)
 }
 
 dependencies {


### PR DESCRIPTION
This pull request updates build configuration settings to improve compatibility and maintain consistency across the project. The most significant changes are related to the Java and Kotlin versions used for building the `skyhigh-16kb-doctor` plugin, as well as a minor update to the application plugin declaration.

**Build configuration updates:**

* Changed the Java source and target compatibility from version 21 to version 17 in `skyhigh-16kb-doctor/plugin/build.gradle.kts` to ensure broader compatibility and align with project requirements.
* Updated the Kotlin JVM toolchain version from 21 to 17 in `skyhigh-16kb-doctor/plugin/build.gradle.kts` for consistency with the Java version.

**Plugin declaration adjustment:**

* Removed the explicit version from the `io.github.sparrow007.skyhigh.16kb-doctor` plugin declaration in `app/build.gradle.kts`, likely to use the version managed elsewhere or default to the latest.