### PR TITLE
Bump SkyHigh 16KB Doctor version to 1.0.2 in build configuration

### DIFF
--- a/skyhigh-16kb-doctor/plugin/build.gradle.kts
+++ b/skyhigh-16kb-doctor/plugin/build.gradle.kts
@@ -74,7 +74,7 @@ mavenPublishing {
 }
 
 mavenPublishing {
-    coordinates("io.github.sparrow007", "skyhigh-16kb-doctor", "1.0.1")
+    coordinates("io.github.sparrow007", "skyhigh-16kb-doctor", "1.0.2")
 
     pom {
         name.set("SkyHigh 16KB Doctor")


### PR DESCRIPTION
### Description

Updating the version from 1.0.1 to 1.0.2

- Updated the JVM version targeting 17
- https://github.com/sparrow007/skyhigh-16kb-doctor/issues/6 (fixed

