### PR TITLE
Remove unnecessary gradle dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 agp = "8.12.2"
-androidPdfViewer = "3.2.0-beta.1"
 kotlin = "2.0.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"
@@ -10,7 +9,6 @@ appcompat = "1.6.1"
 material = "1.10.0"
 
 [libraries]
-android-pdf-viewer = { module = "com.github.barteksc:android-pdf-viewer", version.ref = "androidPdfViewer" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/skyhigh-16kb-doctor/plugin/build.gradle.kts
+++ b/skyhigh-16kb-doctor/plugin/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     signing
     id("com.gradle.plugin-publish") version "1.2.1"
     kotlin("jvm") version "1.9.20"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.20"
     id("com.vanniktech.maven.publish") version "0.34.0"
 }
 
@@ -31,13 +30,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 dependencies {
     implementation(gradleApi())
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.20")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
-    testImplementation("io.mockk:mockk:1.13.8")
     testImplementation(gradleTestKit())
-    testImplementation("org.assertj:assertj-core:3.24.2")
 }
 
 sourceSets {


### PR DESCRIPTION
### Pull Request Summary

This PR removes unused and unnecessary dependencies to simplify the project and reduce build overhead.

#### Changes:

* **Removed `android-pdf-viewer`**

  * Deleted the library from the codebase.
  * Removed its version entry from `gradle/libs.versions.toml`.

* **Removed unused dependencies**

  * `org.jetbrains.kotlin:kotlin-stdlib`
  * `org.jetbrains.kotlinx:kotlinx-serialization-json`
  * `org.junit.jupiter:junit-jupiter`
  * `io.mockk:mockk`
  * `org.assertj:assertj-core`
  * `org.jetbrains.kotlin.plugin.serialization`

#### Impact:

* Cleaner dependency management.
* Reduced build size and potential security/update surface.
* No functional impact on the app since the removed dependencies were unused.

