### PR TITLE
Add manual publish workflow for Maven to CI configuration

### DIFF
--- a/.github/workflows/maven-publish-ci.yml
+++ b/.github/workflows/maven-publish-ci.yml
@@ -1,0 +1,26 @@
+name: Manual Publish to Maven
+
+on:
+  workflow_dispatch:
+
+jobs:
+  manual-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Publish to Maven
+        run: ./gradlew publishToMavenCentral
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/skyhigh-16kb-doctor/plugin/build.gradle.kts
+++ b/skyhigh-16kb-doctor/plugin/build.gradle.kts
@@ -67,7 +67,7 @@ mavenPublishing {
 }
 
 mavenPublishing {
-    coordinates("io.github.sparrow007", "skyhigh-16kb-doctor", "1.0.2")
+    coordinates("io.github.sparrow007", "skyhigh-16kb-doctor", "1.0.2-test")
 
     pom {
         name.set("SkyHigh 16KB Doctor")


### PR DESCRIPTION
This pull request introduces a new workflow for manually publishing the `skyhigh-16kb-doctor` plugin to Maven Central and updates the Maven coordinates for test publishing. The main focus is on enabling manual publishing through GitHub Actions and ensuring the artifact is published under a test version.

**CI/CD workflow improvements:**

* Added a new GitHub Actions workflow `.github/workflows/maven-publish-ci.yml` to allow manual publishing of the plugin to Maven Central using `workflow_dispatch`. This workflow sets up the JDK, checks out the code, and runs the publish command with required secrets.

**Maven publishing configuration:**

* Updated the Maven coordinates in `skyhigh-16kb-doctor/plugin/build.gradle.kts` to use the version `1.0.2-test` for test publishing instead of `1.0.2`.